### PR TITLE
feat: support custom sizing via --fi-size

### DIFF
--- a/exampleTemplate.html
+++ b/exampleTemplate.html
@@ -14,7 +14,7 @@
             color: #424649;
             background-color: #FAFAFA;
             padding: 20px;
-            --fi-size: 16px;
+            --fi-size: 18px;
         }
 
         .sliders {
@@ -76,7 +76,7 @@
             properties: ['font-size', '--fi-size'],
             values: [
                 ['13px', '14px'],
-                ['15px', '16px'],
+                ['15px', '18px'],
                 ['18px', '20px'],
                 ['22px', '24px'],
                 ['26px', '28px'],

--- a/exampleTemplate.html
+++ b/exampleTemplate.html
@@ -14,6 +14,7 @@
             color: #424649;
             background-color: #FAFAFA;
             padding: 20px;
+            --fi-size: 16px;
         }
 
         .sliders {
@@ -72,13 +73,13 @@
         };
 
         const sizes = {
-            properties: ['font-size'],
+            properties: ['font-size', '--fi-size'],
             values: [
-                ['13px'],
-                ['15px'],
-                ['18px'],
-                ['22px'],
-                ['26px'],
+                ['13px', '14px'],
+                ['15px', '16px'],
+                ['18px', '20px'],
+                ['22px', '24px'],
+                ['26px', '28px'],
             ],
         }
 

--- a/style.js
+++ b/style.js
@@ -2,6 +2,9 @@ export default {
     display: 'inline-block',
     width: 'var(--fi-size, 1.1em)',
     height: 'var(--fi-size, 1.1em)',
-    marginBottom: 'calc((1em - var(--fi-size, 1.1em)) * 2)',
     strokeWidth: 'var(--fi-stroke, 2px)',
+    marginTop: 'calc((1em - var(--fi-size, 1.1em)) / 2)',
+    marginBottom: 'calc((1em - var(--fi-size, 1.1em)) / 2)',
+    position: 'relative',
+    top: '.14em',
 };

--- a/style.js
+++ b/style.js
@@ -1,8 +1,7 @@
 export default {
     display: 'inline-block',
-    width: '1.2em',
-    height: '1.2em',
-    marginTop: '-.1em',
-    marginBottom: '-.25em',
+    width: 'var(--fi-size, 1.1em)',
+    height: 'var(--fi-size, 1.1em)',
+    marginBottom: 'calc((1em - var(--fi-size, 1.1em)) * 2)',
     strokeWidth: 'var(--fi-stroke, 2px)',
 };


### PR DESCRIPTION
This also changes the default scaling to 110% of the font-size – but we still want custom sizes for our font sizes, so they can now be set via the `--fi-size` css-variable.

- [ ] Make sure fallback works for browser that don't support css vars