### PR TITLE
Auto-generate Typescript typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
 dist-es5
+typings
 example
 .DS_Store

--- a/buildIcons.js
+++ b/buildIcons.js
@@ -24,6 +24,7 @@ const pascalCase = compose(upperFirst, camelCase);
 const filterWhitelisted = compose(fromPairs, filter(([name]) => includes(name, whitelist)), toPairs);
 const outputPath = path.resolve(__dirname, 'dist');
 const outputPathEs5 = path.resolve(__dirname, 'dist-es5');
+const outputPathTypings = path.resolve(__dirname, 'typings');
 
 getIcons()
     .then(write)
@@ -91,7 +92,7 @@ function getAliased() {
 }
 
 function write(icons) {
-    return Promise.all([writeIndex(icons), ...map(writeIcon, icons)]);
+    return Promise.all([writeTypings(map(i => i[0], icons)), writeIndex(icons), ...map(writeIcon, icons)]);
 }
 
 function writeIndex(icons) {
@@ -113,4 +114,19 @@ function writeIcon([name, icon]) {
         writeFile(path.resolve(outputPath, fileName), code),
         writeFile(path.resolve(outputPathEs5, fileName), codeEs5),
     ]);
+}
+
+function writeTypings(names) {
+    const exports = map(n => `export var ${n}: React.ComponentType<Featherico>`, names).join('\n');
+    const typings = `import * as React from 'react'
+
+export type Featherico = {
+    small?: boolean,
+    className?: string
+}
+
+${exports}
+ `;
+
+    return writeFile(path.resolve(outputPathTypings, 'index.d.ts'), typings);
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.0-development",
     "main": "dist-es5/index.js",
     "module": "dist/index.js",
+    "typings": "typings/index.d.ts",
     "description": "Icon set for Small Improvements. Based on feather, exported as React components.",
     "keywords": [
         "icons",
@@ -14,7 +15,7 @@
     "license": "MIT",
     "repository": "SmallImprovements-OpenSource/featherico",
     "scripts": {
-        "build-icons": "rimraf dist dist-es5 && mkdirp dist dist-es5 && node buildIcons",
+        "build-icons": "rimraf dist dist-es5 typings && mkdirp dist dist-es5 typings && node buildIcons",
         "build-example": "rimraf example && mkdirp example && babel-node --presets react,env buildExample",
         "semantic-release": "semantic-release"
     },


### PR DESCRIPTION
Auto-generate Typescript typings in the build process. They are put into `typings/index.d.ts` and referenced in the `package.json` - which means consumers can just install `featherico` and magically receive the correct typings!

Tried and tested in a private project.