### PR TITLE
feat: add style prop

### DIFF
--- a/buildIcons.js
+++ b/buildIcons.js
@@ -52,11 +52,13 @@ async function getIcons() {
 
 function template(name, icon) {
     return `import React from 'react';
-import style from '../style';
+import fontStyle from '../style';
 
 export default React.memo(function ${name}(props) {
+    const baseStyle = props.customStyle ? (props.customStyle === true ? undefined : props.customStyle) : fontStyle;
+
     return (
-        <svg style={props.customStyle ? (props.customStyle === true ? undefined : props.customStyle) : style} className={props.className} width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" preserveAspectRatio="xMaxYMid slice" focusable="false" data-featherico>
+        <svg style={{ ...baseStyle, ...props.style }} className={props.className} width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" preserveAspectRatio="xMaxYMid slice" focusable="false" data-featherico>
             ${icon}
         </svg>
     );
@@ -67,9 +69,10 @@ export default React.memo(function ${name}(props) {
 function badgeTemplate(name, icon) {
     return `import React from 'react';
 
-var style = { verticalAlign: 'middle' };
+const baseStyle = { verticalAlign: 'middle' };
 
 export default React.memo(function ${name}(props) {
+    const style = { ...baseStyle, ...props.style };
     if (props.small) {
         return (
             <svg width="14" height="14" className={props.className} style={style}>
@@ -130,13 +133,15 @@ function writeTypings(icons) {
     const typings = `import * as React from 'react'
 
 export type Featherico = {
-    className?: string,
-    customStyle?: React.CSSProperties | true
+    className?: string;
+    customStyle?: React.CSSProperties | true;
+    style?: React.CSSProperties;
 }
 
 export type FeathericoBadge = {
-    className?: string,
-    small?: boolean,
+    className?: string;
+    small?: boolean;
+    style?: React.CSSProperties;
 }
 
 ${exports}

--- a/buildIcons.js
+++ b/buildIcons.js
@@ -55,7 +55,7 @@ function template(name, icon) {
 import fontStyle from '../style';
 
 export default React.memo(function ${name}(props) {
-    const baseStyle = props.customStyle ? (props.customStyle === true ? undefined : props.customStyle) : fontStyle;
+    var baseStyle = props.customStyle ? (props.customStyle === true ? undefined : props.customStyle) : fontStyle;
 
     return (
         <svg style={{ ...baseStyle, ...props.style }} className={props.className} width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" preserveAspectRatio="xMaxYMid slice" focusable="false" data-featherico>
@@ -69,10 +69,10 @@ export default React.memo(function ${name}(props) {
 function badgeTemplate(name, icon) {
     return `import React from 'react';
 
-const baseStyle = { verticalAlign: 'middle' };
+var baseStyle = { verticalAlign: 'middle' };
 
 export default React.memo(function ${name}(props) {
-    const style = { ...baseStyle, ...props.style };
+    var style = { ...baseStyle, ...props.style };
     if (props.small) {
         return (
             <svg width="14" height="14" className={props.className} style={style}>

--- a/buildIcons.js
+++ b/buildIcons.js
@@ -58,7 +58,7 @@ export default React.memo(function ${name}(props) {
     var baseStyle = props.customStyle ? (props.customStyle === true ? undefined : props.customStyle) : fontStyle;
 
     return (
-        <svg style={{ ...baseStyle, ...props.style }} className={props.className} width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" preserveAspectRatio="xMaxYMid slice" focusable="false" data-featherico>
+        <svg style={Object.assign({}, baseStyle, props.style)} className={props.className} width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" preserveAspectRatio="xMaxYMid slice" focusable="false" data-featherico>
             ${icon}
         </svg>
     );
@@ -72,7 +72,7 @@ function badgeTemplate(name, icon) {
 var baseStyle = { verticalAlign: 'middle' };
 
 export default React.memo(function ${name}(props) {
-    var style = { ...baseStyle, ...props.style };
+    var style = Object.assign({}, baseStyle, props.style);
     if (props.small) {
         return (
             <svg width="14" height="14" className={props.className} style={style}>


### PR DESCRIPTION
Add `style` prop to all components.

Until now it was only possible to replace all styles of a component using `customStyle`. With the new `style` prop the default style can be adjusted and is not completely overwritten. The same prop is added to the badge components.