### PR TITLE
Add script to export all variants as svg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ dist
 dist-es5
 typings
 example
+svg-export
 .DS_Store

--- a/buildSvg.js
+++ b/buildSvg.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import * as icons from './dist';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { toPairs } from 'lodash/fp';
+import { writeFileSync } from 'fs';
+import path from 'path';
+
+const strokeWidths = [
+    ['1.5', 400],
+    ['2', 500],
+    ['2.2', 600],
+];
+
+toPairs(icons).forEach(([iconName, Icon]) => {
+    const svg = renderToStaticMarkup(<Icon />);
+    const fileName = iconName.replaceAll('Icon', 'Icon:');
+    strokeWidths.forEach(([strokeWidth, weight]) => {
+        writeFileSync(
+            path.resolve(__dirname, 'svg-export/', fileName + ':' + weight + '.svg'),
+            '<?xml version="1.0" standalone="yes"?>' +
+                svg
+                    .replaceAll('var(--fi-stroke, 2px)', strokeWidth + 'px')
+                    .replaceAll('stroke-width="2"', `stroke-width="${strokeWidth}"`)
+        );
+    });
+});

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "repository": "SmallImprovements-OpenSource/featherico",
     "scripts": {
         "build": "rimraf dist dist-es5 typings && mkdirp dist dist-es5 typings && node buildIcons",
+        "build-svg": "rimraf svg-export typings && mkdirp svg-export && babel-node --presets @babel/preset-react,@babel/preset-env buildSvg",
         "build-example": "rimraf example && mkdirp example && babel-node --presets @babel/preset-react,@babel/preset-env buildExample",
         "semantic-release": "semantic-release"
     },


### PR DESCRIPTION
This is useful to add them to Figma. Does it make sense...? Could / should this be added to run in the CI to make the downloads available there?