### PR TITLE
feat: add "redo" icon

### DIFF
--- a/aliased.json
+++ b/aliased.json
@@ -4,6 +4,7 @@
     "maximize-2": "maximize",
     "minimize-2": "minimize",
     "rotate-ccw": "undo",
+    "rotate-cw": "redo",
     "share-2": "share",
     "slash": "ban",
     "trash-2": "trash",


### PR DESCRIPTION
Add the existing `rotate-cw` icon from feathericons to featherico as "redo"

<img width="169" alt="Screenshot 2024-09-17 at 18 55 17" src="https://github.com/user-attachments/assets/a8101511-def8-4f9f-b909-3ba2d812757e">
