### PR TITLE
Github Actions: Update Deprecated Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,10 +48,10 @@ jobs:
               with:
                   name: example
                   path: example
-            - uses: google-github-actions/auth@v0.4.0
+            - uses: google-github-actions/auth@v2
               with:
                   credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-            - uses: google-github-actions/upload-cloud-storage@v0.4.0
+            - uses: google-github-actions/upload-cloud-storage@v2
               with:
                   path: example/index.html
                   destination: ${{ secrets.GCP_BUCKET }}/${{ github.sha }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,8 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
                   node-version: '20'
                   cache: npm
@@ -13,7 +13,7 @@ jobs:
               run: npm ci
             - name: Build library
               run: npm run build
-            - uses: actions/upload-artifact@v2
+            - uses: actions/upload-artifact@v4
               with:
                   name: build
                   path: |
@@ -24,11 +24,11 @@ jobs:
         runs-on: ubuntu-latest
         needs: build
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/download-artifact@v2
+            - uses: actions/checkout@v4
+            - uses: actions/download-artifact@v4
               with:
                   name: build
-            - uses: actions/setup-node@v2
+            - uses: actions/setup-node@v4
               with:
                   node-version: '20'
                   cache: npm
@@ -36,7 +36,7 @@ jobs:
               run: npm ci
             - name: Build example
               run: npm run build-example
-            - uses: actions/upload-artifact@v2
+            - uses: actions/upload-artifact@v4
               with:
                   name: example
                   path: example
@@ -44,7 +44,7 @@ jobs:
         runs-on: ubuntu-latest
         needs: build-example
         steps:
-            - uses: actions/download-artifact@v2
+            - uses: actions/download-artifact@v4
               with:
                   name: example
                   path: example
@@ -78,11 +78,11 @@ jobs:
         needs: build
         if: ${{ github.ref == 'refs/heads/main' }}
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/download-artifact@v2
+            - uses: actions/checkout@v4
+            - uses: actions/download-artifact@v4
               with:
                   name: build
-            - uses: actions/setup-node@v2
+            - uses: actions/setup-node@v4
               with:
                   node-version: '20'
             - name: Release


### PR DESCRIPTION
Some v2 versions of Github-provided actions were deprecated, causing our workflow to fail. This updates them together with the Google Cloud actions we used. No other changes were necessary.